### PR TITLE
Replace hardcoded state_entity with config.entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ card_mod:
 	        {% set use_number      = false %}
 	
 	        {# STATE MODE SETTINGS #}
-	        {% set state_entity    = 'switch.plug_6_local' %}
+	        {% set state_entity    = config.entity %}
 	        {% set active_value    = 'on' %}
 	
 	        {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -150,7 +150,7 @@ card_mod:
 	        {% set use_number      = false %}
 	
 	        {# STATE MODE SETTINGS #}
-	        {% set state_entity    = 'switch.plug_6_local' %}
+	        {% set state_entity    = config.entity %}
 	        {% set active_value    = 'on' %}
 	
 	        {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -307,7 +307,7 @@ card_mod:
 	        {% set use_number      = false %}
 	
 	        {# STATE MODE SETTINGS #}
-	        {% set state_entity    = 'switch.plug_6_local' %}
+	        {% set state_entity    = config.entity %}
 	        {% set active_value    = 'on' %}
 	
 	        {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -428,7 +428,7 @@ card_mod:
 	        {% set use_number      = false %}
 	
 	        {# STATE MODE SETTINGS #}
-	        {% set state_entity    = 'switch.plug_6_local' %}
+	        {% set state_entity    = config.entity %}
 	        {% set active_value    = 'on' %}
 	
 	        {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -772,7 +772,7 @@ card_mod:
 	        {% set use_number      = false %}
 	
 	        {# STATE MODE SETTINGS #}
-	        {% set state_entity    = 'switch.plug_6_local' %}
+	        {% set state_entity    = config.entity %}
 	        {% set active_value    = 'on' %}
 	
 	        {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -926,7 +926,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -1085,7 +1085,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -1202,7 +1202,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -1367,7 +1367,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -1696,7 +1696,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -1814,7 +1814,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -1906,7 +1906,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -2014,7 +2014,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -2135,7 +2135,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -2294,7 +2294,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -2393,7 +2393,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -2489,7 +2489,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -2606,7 +2606,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -2707,7 +2707,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -2837,7 +2837,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -2923,7 +2923,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -3319,7 +3319,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -3535,7 +3535,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -3987,7 +3987,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS (for "intensity") #}
@@ -4191,7 +4191,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -4346,7 +4346,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -4514,7 +4514,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -4665,7 +4665,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -4806,7 +4806,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -4968,7 +4968,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -5117,7 +5117,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -5280,7 +5280,7 @@ card_mod:
         /* ================= USER CONFIGURATION ================= */
         
         {% set use_number      = false %}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
         {% set number_entity   = 'sensor.plug_power' %}
 
@@ -5440,7 +5440,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -5586,7 +5586,7 @@ card_mod:
         {% set use_number      = false %}
 
         {# STATE MODE SETTINGS #}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
 
         {# OPTIONAL: NUMBER MODE SETTINGS #}
@@ -5752,7 +5752,7 @@ card_mod:
       .shape {
         {# ========== USER CONFIG ========== #}
         {% set use_number      = false %}
-        {% set state_entity    = 'switch.plug_6_local' %}
+        {% set state_entity    = config.entity %}
         {% set active_value    = 'on' %}
         {% set number_entity   = 'sensor.plug_power' %}
         {# '>' '<' '=' '>=' '<=' #}


### PR DESCRIPTION
Use generic config.entity instead of a hardcoded string, to make the config easier to copy-paste, without the need of changes